### PR TITLE
Enforce short array syntax for php 5.6

### DIFF
--- a/php/php-codesniffer-standard/VIISON/ruleset-5.6.xml
+++ b/php/php-codesniffer-standard/VIISON/ruleset-5.6.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!-- Place this file in you Shopware plugin's root directory and rename it to phpcs.xml -->
+<ruleset name="VIISON-5.6">
+    <description>VIISON styling rules specialize for a specific php version</description>
+
+    <!-- Use the VIISON ruleset installed by composer -->
+    <rule ref="./vendor/viison/style-guide/php/php-codesniffer-standard/VIISON">
+        <include-pattern>*.php</include-pattern>
+    </rule>
+
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax.Found">
+      <type>error</type>
+    </rule>
+</ruleset>


### PR DESCRIPTION
Since we use different syntax for different php versions it would be nice if we could configure our phpcs.xml

Problem:
 - ViisonCommon => PHP 5.3 with long array syntax
 - ViisonPickwareCommon => PHP 5.6 with short array syntax

I always mix it up, or at least need to look it up

### New phpcs.xml
```xml
<?xml version="1.0"?>
<ruleset name="ShopwarePlugins">
    <!-- Use the VIISON ruleset installed by composer -->
    <rule ref="./vendor/viison/style-guide/php/php-codesniffer-standard/VIISON/ruleset-5.6.xml">
        <include-pattern>*.php</include-pattern>
    </rule>

    <!-- Exclude all shared dependencies -->
    <exclude-pattern>*/ViisonCommon/*</exclude-pattern>
</ruleset>
```

Result:
```bash
✗ phpcs -n .

FILE: ...cts/shopware-plugins/Community/Core/ViisonPickwareMobile/ViisonPickwareCommon/Classes/Util.php
----------------------------------------------------------------------------------------------------
FOUND 8 ERRORS AFFECTING 8 LINES
----------------------------------------------------------------------------------------------------
 146 | ERROR | [x] Short array syntax must be used to define arrays
 198 | ERROR | [x] Short array syntax must be used to define arrays
 218 | ERROR | [x] Short array syntax must be used to define arrays
 238 | ERROR | [x] Short array syntax must be used to define arrays
 241 | ERROR | [x] Short array syntax must be used to define arrays
 274 | ERROR | [x] Short array syntax must be used to define arrays
 277 | ERROR | [x] Short array syntax must be used to define arrays
 288 | ERROR | [x] Short array syntax must be used to define arrays
----------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 8 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------------------------------------


FILE: ...ore/ViisonPickwareMobile/ViisonPickwareCommon/Controllers/Api/ViisonPickwareCommonVariants.php
----------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------------------------------------
 56 | ERROR | [x] Short array syntax must be used to define arrays
----------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------------------------------------


FILE: ...reMobile/ViisonPickwareCommon/Controllers/Backend/ViisonPickwareCommonBarcodeLabelPrinting.php
----------------------------------------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 3 LINES
----------------------------------------------------------------------------------------------------
 517 | ERROR | [x] Short array syntax must be used to define arrays
 546 | ERROR | [x] Short array syntax must be used to define arrays
 921 | ERROR | [x] Short array syntax must be used to define arrays
----------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 3 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------------------------------------


FILE: ...kwareMobile/ViisonPickwareCommon/Test/Tests/Controllers/Api/ViisonPickwareCommonOrdersTest.php
----------------------------------------------------------------------------------------------------
FOUND 7 ERRORS AFFECTING 7 LINES
----------------------------------------------------------------------------------------------------
  27 | ERROR | [x] Short array syntax must be used to define arrays
  62 | ERROR | [x] Short array syntax must be used to define arrays
  88 | ERROR | [x] Short array syntax must be used to define arrays
 127 | ERROR | [x] Short array syntax must be used to define arrays
 168 | ERROR | [x] Short array syntax must be used to define arrays
 205 | ERROR | [x] Short array syntax must be used to define arrays
 216 | ERROR | [x] Short array syntax must be used to define arrays
----------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 7 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------------------------------------


FILE: ...areMobile/ViisonPickwareCommon/Test/Tests/Controllers/Api/ViisonPickwareCommonVariantsTest.php
----------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------------------------------------
 23 | ERROR | [x] Short array syntax must be used to define arrays
----------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------------------------------------

```