### PR TITLE
Add timeFormat Shopware global

### DIFF
--- a/javascript/shopware-plugin/eslintrc.js
+++ b/javascript/shopware-plugin/eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
         'ViisonCommonApp': false,
         'ViisonCurrencyFormatter': false,
         'Shopware': false,
+        'timeFormat': false,
     },
     rules: {
         // Downgrade max-len to warning since this is impractical with ExtJS's protracted class names


### PR DESCRIPTION
This PR adds the Shopware global `timeFormat` to the shopware-plugin `.eslintrc.js`