### PR TITLE
Validate composer.json and composer.lock on changes in pre-commit hook

### DIFF
--- a/git-hooks/shopware-plugin/pre-commit
+++ b/git-hooks/shopware-plugin/pre-commit
@@ -2,6 +2,7 @@
 #
 # Pre-commit Git hook.
 # Runs PHP CS and ESLint on all staged PHP and JavaScript files, respectively.
+# Also partially validates composer.json/composer.lock, if changed.
 
 repo_dir=$(pwd)
 
@@ -44,7 +45,9 @@ if [ ! -f "${repo_dir}/phpcs.xml" ]; then
     echo "${text_red}Cannot run PHP code style check, because a 'phpcs.xml' was not found in $(realpath ${repo_dir}).${text_reset}"
     exit 1
 fi
-echo -e "\nComposer package 'viison/style-guide' is installed, running PHP Code Sniffer on staged PHP files..."
+echo -e "\nComposer package 'viison/style-guide' is installed, will run PHP Code Sniffer on staged PHP files..."
+
+did_composer_validate=0
 for i in "${changedFiles[@]}"; do
     if [[ $i == *.php ]] && [ -f $i ]; then
         $(which phpcs) --warning-severity=0 $i
@@ -53,6 +56,27 @@ for i in "${changedFiles[@]}"; do
             # File has code style issues
             ((codeStyleErrors++))
         fi
+    fi
+    # If a composer-related file changed, run `composer validate`.
+    if ( [[ "$i" == composer.json ]] || [[ "$i" == composer.lock ]] ) && [[ "$did_composer_validate" == 0 ]]; then
+        if ! type composer &> /dev/null
+        then
+            printf 'ERROR: Cannot validate changes to %q.\n' "$i" >&2
+            printf 'ERROR: No composer binary has been found.\n' >&2
+            exit 1
+        fi
+        # Capture composer validate output and only display it if validation
+        # failed, as it is quite verbose.
+        set +e
+        composer_validate_output="$(LC_ALL=C composer validate --no-check-all --no-check-publish 2>&1)"
+        composer_validate_exit="$?"
+        set -e
+        if [[ "$composer_validate_exit" != 0 ]]; then
+            printf 'composer validate: %s\n' "$composer_validate_output" >&2
+            ((codeStyleErrors++))
+        fi
+        composer_validate_output=
+        did_composer_validate=1
     fi
 done
 


### PR DESCRIPTION
For example, this will fail if `composer.lock`'s `content-hash` has not been updated after changing significant fields in `composer.json`.

Note: I chose to use `composer validate` instead of writing custom validation logic, because the logic for `content-hash` is quite specific and I do not think it's guaranteed to never change: <https://github.com/composer/composer/blob/1.6.5/src/Composer/Package/Locker.php#L72-L102>

Note: `composer validate` complains about more things than we care about, but I configured it to not fail for things like missing description/license fields or plugin naming. It will, however, still output such complaints as warnings (without specifying the exact cause of error) like this:
```
composer validate: ./composer.json is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
See https://getcomposer.org/doc/04-schema.md for details on the schema
The lock file is not up to date with the latest changes in composer.json, it is recommended that you run `composer update`.
No license specified, it is recommended to do so. For closed-source software you may use "proprietary" as license.
description : The property description is required
Name "Viison/PickwareERP" does not match the best practice (e.g. lower-cased/with-dashes). We suggest using "viison/pickware-erp" instead. As such you will not be able to submit it to Packagist.
```

However, I only output anything by `composer validate`, if the validation actually failed.