### PR TITLE
Fix running eslint for pre-push in a symlinked directory

### DIFF
--- a/git-hooks/shopware-plugin/pre-push
+++ b/git-hooks/shopware-plugin/pre-push
@@ -41,6 +41,8 @@ if [ -f "${repo_dir}/package.json" ]; then
         echo "NPM package 'viison-style-guide' is installed, running ESLint on all JavaScript files..."
         (
             set -e
+            # Execute eslint in the worktree to avoid an issue with absolute directory arguments in which the directory
+            # is a symbolic link in at least eslint 3.19.0 or its dependencies.
             cd -- "$repo_dir"
             node ./node_modules/eslint/bin/eslint.js --quiet .
         ) || exit 1

--- a/git-hooks/shopware-plugin/pre-push
+++ b/git-hooks/shopware-plugin/pre-push
@@ -39,7 +39,11 @@ if [ -f "${repo_dir}/package.json" ]; then
     fi
     if [ -d "${repo_dir}/node_modules/viison-style-guide" ]; then
         echo "NPM package 'viison-style-guide' is installed, running ESLint on all JavaScript files..."
-        node $repo_dir/node_modules/eslint/bin/eslint.js --quiet $repo_dir || exit 1
+        (
+            set -e
+            cd -- "$repo_dir"
+            node ./node_modules/eslint/bin/eslint.js --quiet .
+        ) || exit 1
         echo -e "${text_green}JavaScript code style check passed.${text_reset}\n"
     fi
 fi


### PR DESCRIPTION
eslint or one of its dependencies fails when eslint is passed an absolute directory argument which is a symlink. This pull request implements a workaround.

`cd MyRegularProject && ./node_modules/.bin/eslint "$(pwd)"` works.

`ln -s MyRegularProject  MySymlinkedProject && cd MySymlinkedProject && ./node_modules/.bin/eslint "$(pwd)"` does not and fails with an error like this:

```
Referenced from: /build/MySymlinkedProject/node_modules/autoprefixer/package.json
Error: Cannot find module 'eslint-config-postcss/es5'
Referenced from: /build/MySymlinkedProject/node_modules/autoprefixer/package.json
    at ModuleResolver.resolve (/build/MyRegularProject/node_modules/eslint/lib/util/module-resolver.js:74:19)
    at resolve (/build/MyRegularProject/node_modules/eslint/lib/config/config-file.js:515:25)
    at load (/build/MyRegularProject/node_modules/eslint/lib/config/config-file.js:532:26)
    at configExtends.reduceRight (/build/MyRegularProject/node_modules/eslint/lib/config/config-file.js:424:36)
    at Array.reduceRight (<anonymous>)
    at applyExtends (/build/MyRegularProject/node_modules/eslint/lib/config/config-file.js:408:28)
    at Object.load (/build/MyRegularProject/node_modules/eslint/lib/config/config-file.js:566:22)
    at loadConfig (/build/MyRegularProject/node_modules/eslint/lib/config.js:63:33)
    at getLocalConfig (/build/MyRegularProject/node_modules/eslint/lib/config.js:130:29)
    at Config.getConfig (/build/MyRegularProject/node_modules/eslint/lib/config.js:260:26)
```